### PR TITLE
Added _toString to StringValueObject for generic use

### DIFF
--- a/src/Domain/Model/ValueObject/StringValueObject.php
+++ b/src/Domain/Model/ValueObject/StringValueObject.php
@@ -34,4 +34,9 @@ abstract class StringValueObject implements ValueObject
     {
         return new static($value);
     }
+    
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }


### PR DESCRIPTION
The string value object don't have any method to get "magicaly" the own string value. Now we have.