### PR TITLE
Add UTC as a default timezone when instance DateTimeValueObject

### DIFF
--- a/src/Domain/Model/ValueObject/DateTimeValueObject.php
+++ b/src/Domain/Model/ValueObject/DateTimeValueObject.php
@@ -5,6 +5,15 @@ namespace PcComponentes\Ddd\Domain\Model\ValueObject;
 
 class DateTimeValueObject extends \DateTimeImmutable implements ValueObject
 {
+    public function __construct($time = 'now', $timezone = null)
+    {
+        if (null === $timezone) {
+            $timezone = new \DateTimeZone('UTC');
+        }
+
+        parent::__construct($time, $timezone);
+    }
+
     final public static function from(string $str): self
     {
         return new static($str, new \DateTimeZone('UTC'));


### PR DESCRIPTION
Co-Authored-By: Zoilo Mora <zoilo.mora@hotmail.com>