### PR TITLE
Sort function to CollectionValueObject added

### DIFF
--- a/src/Domain/Model/ValueObject/CollectionValueObject.php
+++ b/src/Domain/Model/ValueObject/CollectionValueObject.php
@@ -62,6 +62,14 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         return \array_reduce($this->items, $func, $initial);
     }
 
+    public function sort(callable $func)
+    {
+        $items = $this->items;
+        \usort($items, $func);
+
+        return new static($items);
+    }
+
     public function isEmpty(): bool
     {
         return 0 === $this->count();

--- a/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
+++ b/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
@@ -49,6 +49,22 @@ class CollectionValueObjectTest extends TestCase
     /**
      * @test
      */
+    public function given_collection_when_ask_to_sort_then_return_new_sorted_collection()
+    {
+        $collection = CollectionValueObject::from([5, 1, 4, 2, 3]);
+        $sorted = $collection->sort(
+            function ($a , $b){
+                return $a > $b;
+            }
+        );
+
+        $this->assertEquals([5, 1, 4, 2, 3], $collection->jsonSerialize());
+        $this->assertEquals([1, 2, 3, 4, 5], $sorted->jsonSerialize());
+    }
+
+    /**
+     * @test
+     */
     public function given_collection_when_ask_to_filter_then_return_expected_info()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);


### PR DESCRIPTION
Sort function to CollectionValueObject added to allow create sort function on child classes. Example:

```php
final class Messages extends CollectionValueObject
{
    // (...)
    public function sortAscByCreatedAt(): self
    {
         return $this->sort(
             static fn(Message $a, Message $b) => $a->createdAt() > $b->createdAt()
         );
    }
    // (...)
}
```