### PR TITLE
Obtain first item

### DIFF
--- a/src/Domain/Model/ValueObject/CollectionValueObject.php
+++ b/src/Domain/Model/ValueObject/CollectionValueObject.php
@@ -54,7 +54,7 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
 
     public function map(callable $func): CollectionValueObject
     {
-        return new self(\array_map($func, $this->items));
+        return new static(\array_map($func, $this->items));
     }
 
     public function reduce(callable $func, $initial)

--- a/src/Domain/Model/ValueObject/CollectionValueObject.php
+++ b/src/Domain/Model/ValueObject/CollectionValueObject.php
@@ -105,7 +105,7 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         );
     }
 
-    protected function first()
+    public function first()
     {
         return $this->items[(string)array_key_first($this->items)] ?? null;
     }

--- a/src/Domain/Model/ValueObject/CollectionValueObject.php
+++ b/src/Domain/Model/ValueObject/CollectionValueObject.php
@@ -107,6 +107,6 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
 
     public function first()
     {
-        return $this->items[(string)array_key_first($this->items)] ?? null;
+        return $this->items[array_key_first($this->items)] ?? null;
     }
 }

--- a/src/Domain/Model/ValueObject/CollectionValueObject.php
+++ b/src/Domain/Model/ValueObject/CollectionValueObject.php
@@ -104,4 +104,9 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
             static fn ($current) => $current !== $item,
         );
     }
+
+    protected function first()
+    {
+        return $this->items[(string)array_key_first($this->items)] ?? null;
+    }
 }

--- a/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
+++ b/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
@@ -138,4 +138,42 @@ class CollectionValueObjectTest extends TestCase
         $this->assertEquals([1, 2, 3, 4], $collection->jsonSerialize());
         $this->assertEquals([1, 2, 4], $newCollection->jsonSerialize());
     }
+
+    /**
+     * @test
+     */
+    public function given_an_empty_collection_when_ask_to_obtain_first_item_then_return_null()
+    {
+        $collection = CollectionValueObjectTested::from([]);
+        $item = $collection->firstItem();
+
+        $this->assertEquals(null, $item);
+    }
+
+    /**
+     * @test
+     */
+    public function given_a_hash_map_collection_when_ask_to_obtain_first_item_then_return_first_item()
+    {
+        $collection = CollectionValueObjectTested::from(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+        $item = $collection->firstItem();
+
+        $this->assertEquals(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], $collection->jsonSerialize());
+        $this->assertEquals(1, $item);
+    }
+
+    /**
+     * @test
+     */
+    public function given_a_collection_when_ask_to_obtain_first_item_then_return_first_item()
+    {
+        $collection = CollectionValueObjectTested::from([1, 2, 3, 4]);
+        $item = $collection->firstItem();
+
+        $this->assertEquals([1, 2, 3, 4], $collection->jsonSerialize());
+        $this->assertEquals(1, $item);
+        $this->assertNotEquals(2, $item);
+        $this->assertNotEquals(3, $item);
+        $this->assertNotEquals(4, $item);
+    }
 }

--- a/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
+++ b/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
@@ -155,11 +155,12 @@ class CollectionValueObjectTest extends TestCase
      */
     public function given_a_hash_map_collection_when_ask_to_obtain_first_item_then_return_first_item()
     {
-        $collection = CollectionValueObjectTested::from(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+        $firstItem = 1;
+        $collection = CollectionValueObjectTested::from(['a' => $firstItem, 'b' => 2, 'c' => 3, 'd' => 4]);
         $item = $collection->firstItem();
 
-        $this->assertEquals(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], $collection->jsonSerialize());
-        $this->assertEquals(1, $item);
+        $this->assertEquals(['a' => $firstItem, 'b' => 2, 'c' => 3, 'd' => 4], $collection->jsonSerialize());
+        $this->assertEquals($firstItem, $item);
     }
 
     /**
@@ -167,11 +168,12 @@ class CollectionValueObjectTest extends TestCase
      */
     public function given_a_collection_when_ask_to_obtain_first_item_then_return_first_item()
     {
-        $collection = CollectionValueObjectTested::from([1, 2, 3, 4]);
+        $firstItem = 1;
+        $collection = CollectionValueObjectTested::from([$firstItem, 2, 3, 4]);
         $item = $collection->firstItem();
 
-        $this->assertEquals([1, 2, 3, 4], $collection->jsonSerialize());
-        $this->assertEquals(1, $item);
+        $this->assertEquals([$firstItem, 2, 3, 4], $collection->jsonSerialize());
+        $this->assertEquals($firstItem, $item);
         $this->assertNotEquals(2, $item);
         $this->assertNotEquals(3, $item);
         $this->assertNotEquals(4, $item);

--- a/tests/Domain/Model/ValueObject/CollectionValueObjectTested.php
+++ b/tests/Domain/Model/ValueObject/CollectionValueObjectTested.php
@@ -16,4 +16,9 @@ class CollectionValueObjectTested extends CollectionValueObject
     {
         return $this->removeItem($item);
     }
+
+    public function firstItem()
+    {
+        return $this->first();
+    }
 }


### PR DESCRIPTION
obtain first item in collection, avoiding pointer errors when calling current after object has been passed by reference