### PR TITLE
fix: Keep microseconds in DateTimeValueObject

### DIFF
--- a/src/Domain/Model/ValueObject/DateTimeValueObject.php
+++ b/src/Domain/Model/ValueObject/DateTimeValueObject.php
@@ -6,6 +6,7 @@ namespace PcComponentes\Ddd\Domain\Model\ValueObject;
 class DateTimeValueObject extends \DateTimeImmutable implements ValueObject
 {
     private const TIME_ZONE = 'UTC';
+    private const TIME_FORMAT = 'Y-m-d\TH:i:s.uP';
 
     final private function __construct($time, $timezone)
     {
@@ -26,7 +27,7 @@ class DateTimeValueObject extends \DateTimeImmutable implements ValueObject
     {
         $dateTime = \DateTimeImmutable::createFromFormat($format, $str, new \DateTimeZone(self::TIME_ZONE));
 
-        return static::from($dateTime->format(\DATE_ATOM));
+        return static::from($dateTime->format(self::TIME_FORMAT));
     }
 
     final public static function fromTimestamp(int $timestamp): static

--- a/tests/Domain/Model/ValueObject/DateTimeValueObjectTest.php
+++ b/tests/Domain/Model/ValueObject/DateTimeValueObjectTest.php
@@ -16,4 +16,15 @@ class DateTimeValueObjectTest extends TestCase
         $datetime = DateTimeValueObject::from('2000-01-02 03:04:05');
         $this->assertEquals('2000-01-02T03:04:05+00:00', $datetime->jsonSerialize());
     }
+
+    /**
+     * @test
+     */
+    public function given_date_in_timestamp_with_microseconds_when_ask_to_get_info_then_return_expected_info()
+    {
+        $dateTimeMicroSeconds = '1663839726.123456';
+
+        $datetime = DateTimeValueObject::fromFormat('U.u', $dateTimeMicroSeconds);
+        $this->assertEquals($dateTimeMicroSeconds, $datetime->format('U.u'));
+    }
 }


### PR DESCRIPTION
- Keep microseconds in DateTimeValueObject