### PR TITLE
Prevent generate not UTC datetime

### DIFF
--- a/src/Domain/Model/ValueObject/DateTimeValueObject.php
+++ b/src/Domain/Model/ValueObject/DateTimeValueObject.php
@@ -15,7 +15,9 @@ class DateTimeValueObject extends \DateTimeImmutable implements ValueObject
 
     final public static function from(string $str): static
     {
-        return new static($str, new \DateTimeZone(self::TIME_ZONE));
+        $timeZone = new \DateTimeZone(self::TIME_ZONE);
+
+        return (new static($str, $timeZone))->setTimezone($timeZone);
     }
 
     final public static function now(): static


### PR DESCRIPTION
**fix: prevent generate not UTC datetime**

This value object was thinking for use UTC as TimeZone standar. However, it allow set other timezone by passing it on "from" factory:

```php
$date = DateTimeValueObject::from('2025-01-10T15:16:11+01:00')

echo $date->format(\DATE_ATOM) ; // result 2025-01-10T15:16:11+01:00
```

Before this fix, date was transformed to UTC, expected result: 2025-01-10T**14**:16:11+**00:00**

