### PR TITLE
Add CollectionCalueObject equivalentTo function

### DIFF
--- a/src/Domain/Model/ValueObject/CollectionValueObject.php
+++ b/src/Domain/Model/ValueObject/CollectionValueObject.php
@@ -80,9 +80,23 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         return 0 === $this->count();
     }
 
-    public function equalTo(CollectionValueObject $other): bool
+    public function equalTo(self $other): bool
     {
         return static::class === \get_class($other) && $this->items == $other->items;
+    }
+
+    public function equivalentTo(self $other): bool
+    {
+        if (static::class !== $other::class || $this->count() !== $other->count()) {
+            return false;
+        }
+
+        $sortFunc = static fn ($a, $b) => $a <=> $b;
+
+        $a = $this->sort($sortFunc);
+        $b = $other->sort($sortFunc);
+
+        return $a->equalTo($b);
     }
 
     final public function jsonSerialize(): array
@@ -92,7 +106,7 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
 
     public function first()
     {
-        return $this->items[array_key_first($this->items)] ?? null;
+        return $this->items[\array_key_first($this->items)] ?? null;
     }
 
     public function value(): array

--- a/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
+++ b/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
@@ -8,9 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class CollectionValueObjectTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function given_empty_collection_when_ask_to_get_info_then_return_expected_info()
     {
         $collection = CollectionValueObject::from([]);
@@ -19,9 +17,7 @@ class CollectionValueObjectTest extends TestCase
         $this->assertTrue($collection->isEmpty());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_collection_when_ask_to_get_info_then_return_expected_info()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);
@@ -30,91 +26,76 @@ class CollectionValueObjectTest extends TestCase
         $this->assertFalse($collection->isEmpty());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_collection_when_ask_to_reduce_then_return_expected_info()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);
         $reduced = $collection->reduce(
-            function ($carry, $current) {
-                return $carry . $current;
-            },
-            ''
+            static fn ($carry, $current) => $carry . $current,
+            '',
         );
 
         $this->assertEquals('1234', $reduced);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_integerish_collection_when_ask_to_sort_then_return_new_sorted_collection()
     {
         $collection = CollectionValueObject::from([5, 1, 4, 2, 3]);
         $sorted = $collection->sort(
-            function ($a, $b) {
-               return $a - $b;
-            }
+            static fn ($a, $b) => $a - $b,
         );
 
         $this->assertEquals([5, 1, 4, 2, 3], $collection->jsonSerialize());
         $this->assertEquals([1, 2, 3, 4, 5], $sorted->jsonSerialize());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_collection_when_ask_to_sort_then_return_new_sorted_collection()
     {
         $collection = CollectionValueObject::from(['5a', '1', '4', '2', '3']);
         $sorted = $collection->sort(
-            function ($a, $b) {
+            static function ($a, $b) {
                 if ($a == $b) {
                     return 0;
                 }
-                return ($a < $b) ? -1 : 1;
-            }
+
+                return $a < $b
+                    ? -1
+                    : 1;
+            },
         );
 
         $this->assertEquals(['5a', '1', '4', '2', '3'], $collection->jsonSerialize());
         $this->assertEquals(['1', '2', '3', '4', '5a'], $sorted->jsonSerialize());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_collection_when_ask_to_filter_then_return_expected_info()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);
         $newCollection = $collection->filter(
-            function ($current) {
-                return 2 !== $current;
-            }
+            static fn ($current) => 2 !== $current,
         );
 
         $this->assertEquals([1, 3, 4], $newCollection->jsonSerialize());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_collection_when_ask_to_walk_then_iterate_for_all_items()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);
         $iterated = [];
         $collection->walk(
-            function ($current) use (&$iterated) {
+            static function ($current) use (&$iterated) {
                 $iterated[] = $current;
-            }
+            },
         );
 
         $this->assertEquals([1, 2, 3, 4], $iterated);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_two_identical_collections_when_ask_to_check_equality_then_return_true()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);
@@ -123,9 +104,7 @@ class CollectionValueObjectTest extends TestCase
         $this->assertTrue($collection->equalTo($other));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_two_different_collections_when_ask_to_check_equality_then_return_false()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);
@@ -134,9 +113,89 @@ class CollectionValueObjectTest extends TestCase
         $this->assertFalse($collection->equalTo($other));
     }
 
+    public function equivalentCollectionValues(): array
+    {
+        $objet1 = new ObjectMock(2, 'paodpada');
+        $objet2 = new ObjectMock(19, 'adsdaadsads');
+
+        return [
+            [[1, 2, 3, 4], [1, 2, 3, 4]],
+            [[1, 2, 3, 4], [4, 3, 2, 1]],
+            [[1, 2, 3, 4], [1, 2, 4, 3]],
+            [[1, 2, 3, 4], [4, 3, 1, 2]],
+            [['1', '2', '3', '4'], ['4', '3', '1', '2']],
+            [['1', '2', '3', '4'], ['1', '2', '4', '3']],
+            [['1', '2', '3', '4'], ['4', '3', '1', '2']],
+            [['1', '1', '1', '4'], ['4', '1', '1', '1']],
+            [
+                [
+                    FloatValueObjectTested::from(1.1),
+                    FloatValueObjectTested::from(6.0),
+                ],
+                [
+                    FloatValueObjectTested::from(1.1),
+                    FloatValueObjectTested::from(6.0),
+                ],
+            ],
+            [[$objet1, $objet2], [$objet1, $objet2]],
+            [[$objet1, $objet2], [$objet2, $objet1]],
+            [[$objet1, $objet1, $objet2], [$objet1, $objet2, $objet1]],
+        ];
+    }
+
     /**
      * @test
+     * @dataProvider equivalentCollectionValues
      */
+    public function given_two_equivalent_collections_when_ask_to_check_equivalency_then_return_true(
+        array $collection,
+        array $other,
+    ) {
+        $collection = CollectionValueObject::from($collection);
+        $other = CollectionValueObject::from($other);
+
+        $this->assertTrue($collection->equivalentTo($other));
+    }
+
+    public function differentCollectionValues(): array
+    {
+        return [
+            [[1, 2, 3, 4], [1, 2, 3, 5]],
+            [[1, 2, 3, 4], [5, 3, 2, 1]],
+            [[1, 2, 3, 4], [1, 2, 5, 3]],
+            [[1, 2, 3, 4], [5, 3, 1, 2]],
+            [['1', '2', '3', '4'], ['5', '3', '1', '2']],
+            [['1', '2', '3', '4'], ['1', '2', '5', '3']],
+            [['1', '2', '3', '4'], ['5', '3', '1', '2']],
+            [['1', '1', '4', '4'], ['4', '1', '1', '1']],
+            [
+                [
+                    FloatValueObjectTested::from(1.1),
+                    FloatValueObjectTested::from(6.0),
+                ],
+                [
+                    FloatValueObjectTested::from(1.3),
+                    FloatValueObjectTested::from(6.0),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider differentCollectionValues
+     */
+    public function given_two_different_collections_when_ask_to_check_equivalency_then_return_false(
+        array $collection,
+        array $other,
+    ) {
+        $collection = CollectionValueObject::from($collection);
+        $other = CollectionValueObject::from($other);
+
+        $this->assertFalse($collection->equivalentTo($other));
+    }
+
+    /** @test */
     public function given_collection_when_ask_to_add_item_then_return_new_collection()
     {
         $collection = CollectionValueObjectTested::from([1, 2, 3, 4]);
@@ -146,9 +205,7 @@ class CollectionValueObjectTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5], $newCollection->jsonSerialize());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_collection_when_ask_to_remove_item_then_return_new_collection()
     {
         $collection = CollectionValueObjectTested::from([1, 2, 3, 4]);
@@ -158,9 +215,7 @@ class CollectionValueObjectTest extends TestCase
         $this->assertEquals([1, 2, 4], $newCollection->jsonSerialize());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_an_empty_collection_when_ask_to_obtain_first_item_then_return_null()
     {
         $collection = CollectionValueObjectTested::from([]);
@@ -169,9 +224,7 @@ class CollectionValueObjectTest extends TestCase
         $this->assertEquals(null, $item);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_a_hash_map_collection_when_ask_to_obtain_first_item_then_return_first_item()
     {
         $firstItem = 1;
@@ -182,9 +235,7 @@ class CollectionValueObjectTest extends TestCase
         $this->assertEquals($firstItem, $item);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function given_a_collection_when_ask_to_obtain_first_item_then_return_first_item()
     {
         $firstItem = 1;

--- a/tests/Domain/Model/ValueObject/ObjectMock.php
+++ b/tests/Domain/Model/ValueObject/ObjectMock.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\Ddd\Tests\Domain\Model\ValueObject;
+
+final class ObjectMock
+{
+    public function __construct(private int $a, private string $b)
+    {
+    }
+
+    public function a(): int
+    {
+        return $this->a;
+    }
+
+    public function b(): string
+    {
+        return $this->b;
+    }
+}


### PR DESCRIPTION
feat: add equivalentTo function to collection value object

function is similar to equalTo, but:
- equalTo: two identical collections with different order returned false.
- equivalentTo: two equal collections with different order return true.