### PR TITLE
Improve CollectionValueObject iteration typing

### DIFF
--- a/src/Domain/Model/ValueObject/CollectionValueObject.php
+++ b/src/Domain/Model/ValueObject/CollectionValueObject.php
@@ -3,10 +3,22 @@ declare(strict_types=1);
 
 namespace PcComponentes\Ddd\Domain\Model\ValueObject;
 
-class CollectionValueObject implements \Iterator, \Countable, ValueObject
+/**
+ * Generic collection value object.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ * @implements \IteratorAggregate<TKey, TValue>
+ */
+class CollectionValueObject implements \IteratorAggregate, \Countable, ValueObject
 {
+    /**
+     * @var array<TKey, TValue>
+     * Typed collection items.
+     */
     private array $items;
 
+    /** @param array<TKey, TValue> $items */
     final private function __construct(array $items)
     {
         $this->items = $items;
@@ -17,9 +29,20 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         return new static($items);
     }
 
-    public function current(): mixed
+    /** @return \Traversable<TKey, TValue> */
+    public function getIterator(): \Traversable
     {
-        return \current($this->items);
+        return new \ArrayIterator($this->items);
+    }
+
+    /** @return TValue|null */
+    public function current()
+    {
+        $key = $this->key();
+
+        return null === $key
+            ? null
+            : $this->items[$key];
     }
 
     public function next(): void
@@ -27,6 +50,7 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         \next($this->items);
     }
 
+    /** @return TKey|null */
     public function key(): string|int|null
     {
         return \key($this->items);
@@ -47,31 +71,45 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         return \count($this->items);
     }
 
+    /** @param callable(TValue, TKey): void $func */
     public function walk(callable $func): void
     {
         \array_walk($this->items, $func);
     }
 
+    /**
+     * @param callable(TValue): bool $func
+     * @return TValue|null
+     */
     public function findOne(callable $func)
     {
         return \array_find($this->items, $func);
     }
 
+    /** @param callable(TValue): bool $func */
     public function filter(callable $func): static
     {
         return static::from(\array_values(\array_filter($this->items, $func)));
     }
 
+    /** @param callable(TValue): TValue $func */
     public function map(callable $func): static
     {
         return static::from(\array_map($func, $this->items));
     }
 
+    /**
+     * @template TCarry
+     * @param callable(TCarry, TValue): TCarry $func
+     * @param TCarry $initial
+     * @return TCarry
+     */
     public function reduce(callable $func, $initial)
     {
         return \array_reduce($this->items, $func, $initial);
     }
 
+    /** @param callable(TValue, TValue): int $func */
     public function sort(callable $func): static
     {
         $items = $this->items;
@@ -104,21 +142,25 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         return $a->equalTo($b);
     }
 
+    /** @return array<TKey, TValue> */
     final public function jsonSerialize(): array
     {
         return $this->items;
     }
 
+    /** @return TValue|null */
     public function first()
     {
         return $this->items[\array_key_first($this->items)] ?? null;
     }
 
+    /** @return array<TKey, TValue> */
     public function value(): array
     {
         return $this->items;
     }
 
+    /** @param TValue $item */
     protected function addItem($item): static
     {
         $items = $this->items;
@@ -127,6 +169,7 @@ class CollectionValueObject implements \Iterator, \Countable, ValueObject
         return static::from($items);
     }
 
+    /** @param TValue $item */
     protected function removeItem($item): static
     {
         return $this->filter(

--- a/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
+++ b/tests/Domain/Model/ValueObject/CollectionValueObjectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace PcComponentes\Ddd\Tests\Domain\Model\ValueObject;
 
 use PcComponentes\Ddd\Domain\Model\ValueObject\CollectionValueObject;
+use PcComponentes\Ddd\Domain\Model\ValueObject\FloatValueObject;
 use PHPUnit\Framework\TestCase;
 
 class CollectionValueObjectTest extends TestCase
@@ -96,6 +97,19 @@ class CollectionValueObjectTest extends TestCase
     }
 
     /** @test */
+    public function given_collection_when_iterate_with_foreach_then_keep_items_and_keys()
+    {
+        $collection = CollectionValueObject::from(['a' => 1, 'b' => 2]);
+        $iterated = [];
+
+        foreach ($collection as $key => $item) {
+            $iterated[$key] = $item;
+        }
+
+        $this->assertEquals(['a' => 1, 'b' => 2], $iterated);
+    }
+
+    /** @test */
     public function given_two_identical_collections_when_ask_to_check_equality_then_return_true()
     {
         $collection = CollectionValueObject::from([1, 2, 3, 4]);
@@ -129,12 +143,12 @@ class CollectionValueObjectTest extends TestCase
             [['1', '1', '1', '4'], ['4', '1', '1', '1']],
             [
                 [
-                    FloatValueObjectTested::from(1.1),
-                    FloatValueObjectTested::from(6.0),
+                    FloatValueObject::from(1.1),
+                    FloatValueObject::from(6.0),
                 ],
                 [
-                    FloatValueObjectTested::from(1.1),
-                    FloatValueObjectTested::from(6.0),
+                    FloatValueObject::from(1.1),
+                    FloatValueObject::from(6.0),
                 ],
             ],
             [[$objet1, $objet2], [$objet1, $objet2]],
@@ -170,12 +184,12 @@ class CollectionValueObjectTest extends TestCase
             [['1', '1', '4', '4'], ['4', '1', '1', '1']],
             [
                 [
-                    FloatValueObjectTested::from(1.1),
-                    FloatValueObjectTested::from(6.0),
+                    FloatValueObject::from(1.1),
+                    FloatValueObject::from(6.0),
                 ],
                 [
-                    FloatValueObjectTested::from(1.3),
-                    FloatValueObjectTested::from(6.0),
+                    FloatValueObject::from(1.3),
+                    FloatValueObject::from(6.0),
                 ],
             ],
         ];
@@ -213,6 +227,26 @@ class CollectionValueObjectTest extends TestCase
 
         $this->assertEquals([1, 2, 3, 4], $collection->jsonSerialize());
         $this->assertEquals([1, 2, 4], $newCollection->jsonSerialize());
+    }
+
+    /** @test */
+    public function given_an_empty_collection_when_ask_to_obtain_current_item_then_return_null()
+    {
+        $collection = CollectionValueObject::from([]);
+
+        $this->assertNull($collection->current());
+    }
+
+    /** @test */
+    public function given_a_collection_when_ask_to_obtain_current_item_then_return_expected_item()
+    {
+        $collection = CollectionValueObject::from([1, 2, 3, 4]);
+
+        $this->assertSame(1, $collection->current());
+
+        $collection->next();
+
+        $this->assertSame(2, $collection->current());
     }
 
     /** @test */


### PR DESCRIPTION
  ## Typed iteration for `CollectionValueObject`

  `CollectionValueObject` now uses `IteratorAggregate` with generic PHPDoc annotations instead of relying on `Iterator::current()` for iteration typing.

  This change improves static analysis support, especially in PHPStan. When iterating a typed collection with `foreach`, each item is now inferred as the declared collection value type instead of `T|null`. This removes the need for redundant runtime assertions in consumers that only existed to satisfy static
  analysis.

  ### Breaking changes

  - `CollectionValueObject` no longer implements `Iterator`; it now implements `IteratorAggregate`.
  - `current()` now returns `null` when there is no valid current element, instead of `false`.
  - `foreach` no longer depends on the collection's internal cursor state.

  ### Migration

  - Update collection subclasses to declare their concrete type with `@extends CollectionValueObject<TKey, TValue>`, for example:

  ```php
  /** @extends CollectionValueObject<int, Article> */
  final class Articles extends CollectionValueObject
  {
  }

  - Remove redundant overrides of current() or first() in child collections when they only existed to narrow types.
  - Remove redundant assertions inside foreach loops, such as assert(null !== $item).
  - If you use current() directly, replace checks against false with checks against null.
  - If any code type-hints against Iterator, update it to IteratorAggregate, Traversable, or the concrete collection type.