### PR TITLE
Add UUID v7 generation support

### DIFF
--- a/src/Domain/Model/ValueObject/Uuid.php
+++ b/src/Domain/Model/ValueObject/Uuid.php
@@ -7,6 +7,11 @@ use Ramsey\Uuid\Uuid as RamseyUuid;
 
 class Uuid extends StringValueObject
 {
+    public static function create(): static
+    {
+        return static::v7();
+    }
+
     public static function from(string $value): static
     {
         return parent::from(RamseyUuid::fromString($value)->toString());
@@ -15,6 +20,11 @@ class Uuid extends StringValueObject
     public static function v4(): static
     {
         return static::from(RamseyUuid::uuid4()->toString());
+    }
+
+    public static function v7(): static
+    {
+        return static::from(RamseyUuid::uuid7()->toString());
     }
 
     public static function isValid(string $value): bool

--- a/tests/Domain/Model/ValueObject/UuidTest.php
+++ b/tests/Domain/Model/ValueObject/UuidTest.php
@@ -33,6 +33,26 @@ class UuidTest extends TestCase
     /**
      * @test
      */
+    public function given_uuid_class_when_ask_to_generate_an_uuid_v7_then_return_uuid_instance()
+    {
+        $uuid = Uuid::v7();
+        $this->assertInstanceOf(Uuid::class, $uuid);
+        $this->assertMatchesRegularExpression('/^[0-9A-F]{8}-[0-9A-F]{4}-7[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i', $uuid->value());
+    }
+
+    /**
+     * @test
+     */
+    public function given_uuid_class_when_ask_to_create_then_return_a_v7_uuid_instance()
+    {
+        $uuid = Uuid::create();
+        $this->assertInstanceOf(Uuid::class, $uuid);
+        $this->assertMatchesRegularExpression('/^[0-9A-F]{8}-[0-9A-F]{4}-7[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i', $uuid->value());
+    }
+
+    /**
+     * @test
+     */
     public function given_two_identical_uuids_when_ask_to_check_equality_then_return_true()
     {
         $str = Uuid::from('f25144ac-2ce2-4b14-9d90-494b89fc09e2');


### PR DESCRIPTION
  ## Summary

  Add UUID v7 generation support to the `Uuid` value object.

  This change introduces a dedicated `v7()` factory method and adds a generic `create()` factory that now generates UUID v7 by default.

  ## Changes

  - add `Uuid::v7()` in `src/Domain/Model/ValueObject/Uuid.php`
  - add `Uuid::create()` as the generic factory for new UUIDs
  - keep `Uuid::v4()` available for explicit v4 generation

## Context

  Main advantages of v7 over v4:

  - Better database insert performance
  - Less index fragmentation
  - Natural sorting by creation time
  - Easier debugging and traceability
  - Still works well in distributed systems without central coordination

  v4 is still fine when you only need simple, fully random identifiers.
